### PR TITLE
Adding compression mechanism to the state data

### DIFF
--- a/media-registry.go
+++ b/media-registry.go
@@ -10,15 +10,16 @@ import (
 )
 
 var SYSTEM = sdk.Export(_init)
-var PUBLIC = sdk.Export(registerMedia, areRegistered)
+var PUBLIC = sdk.Export(registerMedia, areRegistered, getMedia)
 
 var OWNER_KEY = []byte("__CONTRACT_OWNER__")
+var INDEX_KEY = []byte("__INDEX__")
 
 func _init() {
 	state.WriteBytes(OWNER_KEY, address.GetSignerAddress())
 }
 
-func _isRegistered(id string) bool {
+func isRegistered(id string) bool {
 	key := []byte(id)
 	return state.ReadString(key) != ""
 }
@@ -26,7 +27,7 @@ func _isRegistered(id string) bool {
 func areRegistered(ids string) string {
 	res := ""
 	for _, id := range strings.Split(ids, ",") {
-		if _isRegistered(id) {
+		if isRegistered(id) {
 			res = res + "1"
 		} else {
 			res = res + "0"
@@ -40,10 +41,15 @@ func registerMedia(mediaID, metadata string) {
 		panic("Only contract owner can register media")
 	}
 	key := []byte(mediaID)
-	if _isRegistered(mediaID) {
+	if isRegistered(mediaID) {
 		panic("The record already exists")
 	}
 	state.WriteString(key, metadata)
+	state.WriteString(INDEX_KEY, "|"+state.ReadString(INDEX_KEY))
+}
+
+func getMedia(id string) string {
+	return state.ReadString([]byte(id))
 }
 
 func main() {}

--- a/media-registry_test.go
+++ b/media-registry_test.go
@@ -33,3 +33,11 @@ func TestAreRegistered(t *testing.T) {
 		require.Equal(t, areRegistered("id1,id2,id3"), "110")
 	})
 }
+
+func TestRecordRetrieval(t *testing.T) {
+	InServiceScope(nil, nil, func(m Mockery) {
+		_init()
+		registerMedia("id1", "test-metadata")
+		require.Equal(t, getMedia("id1"), "test-metadata")
+	})
+}


### PR DESCRIPTION
Problem: State is growing quite fast
Solution: compress before writing into state w/ `gzip`
**NOTE**: `compress` package MUST be whitelisted before deploying